### PR TITLE
Terraform hotfix PR

### DIFF
--- a/16_Oblachnaya_infrastruktura_Terraform/04_Prodvinutye_metody_raboty_with_Terraform/.gitignore
+++ b/16_Oblachnaya_infrastruktura_Terraform/04_Prodvinutye_metody_raboty_with_Terraform/.gitignore
@@ -3,7 +3,6 @@
 .terraform*
 
 .external_modules*
-#**/.external_modules/*
 
 !.terraformrc
 

--- a/16_Oblachnaya_infrastruktura_Terraform/04_Prodvinutye_metody_raboty_with_Terraform/.gitignore
+++ b/16_Oblachnaya_infrastruktura_Terraform/04_Prodvinutye_metody_raboty_with_Terraform/.gitignore
@@ -2,6 +2,9 @@
 **/.terraform/*
 .terraform*
 
+.external_modules*
+#**/.external_modules/*
+
 !.terraformrc
 
 # .tfstate files

--- a/16_Oblachnaya_infrastruktura_Terraform/04_Prodvinutye_metody_raboty_with_Terraform/main.tf
+++ b/16_Oblachnaya_infrastruktura_Terraform/04_Prodvinutye_metody_raboty_with_Terraform/main.tf
@@ -10,7 +10,7 @@ module "vpc_dev" {
 ##module VM
 
 module "marketing_vm" {
-  source         = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main"
+  source         = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=f96532a351d512ef1888e6c12a3d47c65fa10479"
   env_name       = "develop" 
   network_id     = module.vpc_dev.network_id
   subnet_zones   = ["ru-central1-a"]
@@ -18,7 +18,9 @@ module "marketing_vm" {
   instance_name  = "webs"
   instance_count = 1
   image_family   = "ubuntu-2004-lts"
-  public_ip      = true
+  public_ip      = false
+  security_group_ids = [ module.vpc_dev.security_id ]
+
 
   labels = { 
     owner= "v.arzybov",
@@ -33,7 +35,7 @@ module "marketing_vm" {
 }
 
 module "analytics_vm" {
-  source         = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main"
+  source         = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=f96532a351d512ef1888e6c12a3d47c65fa10479"
   env_name       = "stage"
   network_id     = module.vpc_dev.network_id
   subnet_zones   = ["ru-central1-a"]
@@ -41,7 +43,9 @@ module "analytics_vm" {
   instance_name  = "web-stage"
   instance_count = 1
   image_family   = "ubuntu-2004-lts"
-  public_ip      = true
+  public_ip      = false
+  security_group_ids = [ module.vpc_dev.security_id ]
+
 
   labels = { 
     owner= "v.arzybov",
@@ -59,11 +63,11 @@ module "analytics_vm" {
 #Пример передачи cloud-config в ВМ
 data "template_file" "cloudinit" {
   template = file("./cloud-init.yml")
-
+  
     vars = {
     username           = var.username
     ssh_public_key     = file("~/.ssh/id_rsa.pub")
   }
-
+  
 }
 

--- a/16_Oblachnaya_infrastruktura_Terraform/04_Prodvinutye_metody_raboty_with_Terraform/providers.tf
+++ b/16_Oblachnaya_infrastruktura_Terraform/04_Prodvinutye_metody_raboty_with_Terraform/providers.tf
@@ -1,11 +1,17 @@
 terraform {
+  required_version = "~>1.8.4"
   required_providers {
     yandex = {
       source = "yandex-cloud/yandex"
+      version = "~>0.139.0"
+    }
+    template = {
+      source  = "hashicorp/template"
+      version = "~> 2"
     }
   }
-  required_version = "~>1.8.4"
 }
+
 
 provider "yandex" {
   cloud_id                 = var.cloud_id
@@ -16,8 +22,9 @@ provider "yandex" {
 
 ###s3
 
+
 terraform {
-  required_version = "1.8.4"
+ # required_version = "1.8.4"
 
   backend "s3" {
     

--- a/16_Oblachnaya_infrastruktura_Terraform/04_Prodvinutye_metody_raboty_with_Terraform/vpc/outputs.tf
+++ b/16_Oblachnaya_infrastruktura_Terraform/04_Prodvinutye_metody_raboty_with_Terraform/vpc/outputs.tf
@@ -7,3 +7,9 @@ output "subnet_id" {
 
     value = yandex_vpc_subnet.develop.id
 }
+
+output "security_id" {
+
+    value = yandex_vpc_security_group.example.id
+}
+

--- a/16_Oblachnaya_infrastruktura_Terraform/04_Prodvinutye_metody_raboty_with_Terraform/vpc/security.tf
+++ b/16_Oblachnaya_infrastruktura_Terraform/04_Prodvinutye_metody_raboty_with_Terraform/vpc/security.tf
@@ -1,0 +1,86 @@
+variable "security_group_ingress" {
+  description = "secrules ingress"
+  type = list(object(
+    {
+      protocol       = string
+      description    = string
+      v4_cidr_blocks = list(string)
+      port           = optional(number)
+      from_port      = optional(number)
+      to_port        = optional(number)
+  }))
+  default = [
+    {
+      protocol       = "TCP"
+      description    = "разрешить входящий ssh"
+      v4_cidr_blocks = ["0.0.0.0/0"]
+      port           = 22
+    },
+    {
+      protocol       = "TCP"
+      description    = "разрешить входящий  http"
+      v4_cidr_blocks = ["0.0.0.0/0"]
+      port           = 80
+    },
+    {
+      protocol       = "TCP"
+      description    = "разрешить входящий https"
+      v4_cidr_blocks = ["0.0.0.0/0"]
+      port           = 443
+    },
+  ]
+}
+
+
+variable "security_group_egress" {
+  description = "secrules egress"
+  type = list(object(
+    {
+      protocol       = string
+      description    = string
+      v4_cidr_blocks = list(string)
+      port           = optional(number)
+      from_port      = optional(number)
+      to_port        = optional(number)
+  }))
+  default = [
+    { 
+      protocol       = "TCP"
+      description    = "разрешить весь исходящий трафик"
+      v4_cidr_blocks = ["0.0.0.0/0"]
+      from_port      = 0
+      to_port        = 65365
+    }
+  ]
+}
+
+
+resource "yandex_vpc_security_group" "example" {
+  name       = "example_dynamic"
+  network_id = yandex_vpc_network.develop.id
+  folder_id  = var.folder_id
+
+  dynamic "ingress" {
+    for_each = var.security_group_ingress
+    content {
+      protocol       = lookup(ingress.value, "protocol", null)
+      description    = lookup(ingress.value, "description", null)
+      port           = lookup(ingress.value, "port", null)
+      from_port      = lookup(ingress.value, "from_port", null)
+      to_port        = lookup(ingress.value, "to_port", null)
+      v4_cidr_blocks = lookup(ingress.value, "v4_cidr_blocks", null)
+    }
+  }
+
+  dynamic "egress" {
+    for_each = var.security_group_egress
+    content {
+      protocol       = lookup(egress.value, "protocol", null)
+      description    = lookup(egress.value, "description", null)
+      port           = lookup(egress.value, "port", null)
+      from_port      = lookup(egress.value, "from_port", null)
+      to_port        = lookup(egress.value, "to_port", null)
+      v4_cidr_blocks = lookup(egress.value, "v4_cidr_blocks", null)
+    }
+  }
+}

--- a/16_Oblachnaya_infrastruktura_Terraform/04_Prodvinutye_metody_raboty_with_Terraform/vpc/variables.tf
+++ b/16_Oblachnaya_infrastruktura_Terraform/04_Prodvinutye_metody_raboty_with_Terraform/vpc/variables.tf
@@ -19,4 +19,10 @@ variable "cidr" {
 }
 
 
+####checkov vars
+variable "folder_id" {
+  type        = string
+  default     = "b1g51e5v9mh6c4gtt2he"
+  description = "https://cloud.yandex.ru/docs/resource-manager/operations/folder/get-id"
+}
 


### PR DESCRIPTION
```
#tflint 

reivol@Zabbix:~/GitHub/HOMEWORK/16_Oblachnaya_infrastruktura_Terraform/04_Prodvinutye_metody_raboty_with_Terraform$ docker run --rm -v $(pwd):/data -t ghcr.io/terraform-linters/tflint
reivol@Zabbix:~/GitHub/HOMEWORK/16_Oblachnaya_infrastruktura_Terraform/04_Prodvinutye_metody_raboty_with_Terraform$ 
```

```
#checkov

       _               _

   ___| |__   ___  ___| | _______   __

  / __| '_ \ / _ \/ __| |/ / _ \ \ / /

 | (__| | | |  __/ (__|   < (_) \ V /

  \___|_| |_|\___|\___|_|\_\___/ \_/



By Prisma Cloud | version: 3.2.383 

Update available 3.2.383 -> 3.2.385

Run pip3 install -U checkov to update 





terraform scan results:



Passed checks: 11, Failed checks: 0, Skipped checks: 0



Check: CKV_YC_11: "Ensure security group is assigned to network interface."

	PASSED for resource: module.analytics_vm.yandex_compute_instance.vm[0]

	File: /.external_modules/github.com/udjin10/yandex_compute_instance/f96532a351d512ef1888e6c12a3d47c65fa10479/main.tf:24-73

	Calling File: /main.tf:37-60

Check: CKV_YC_2: "Ensure compute instance does not have public IP."

	PASSED for resource: module.analytics_vm.yandex_compute_instance.vm[0]

	File: /.external_modules/github.com/udjin10/yandex_compute_instance/f96532a351d512ef1888e6c12a3d47c65fa10479/main.tf:24-73

	Calling File: /main.tf:37-60

Check: CKV_YC_4: "Ensure compute instance does not have serial console enabled."

	PASSED for resource: module.analytics_vm.yandex_compute_instance.vm[0]

	File: /.external_modules/github.com/udjin10/yandex_compute_instance/f96532a351d512ef1888e6c12a3d47c65fa10479/main.tf:24-73

	Calling File: /main.tf:37-60

Check: CKV_YC_11: "Ensure security group is assigned to network interface."

	PASSED for resource: module.marketing_vm.yandex_compute_instance.vm[0]

	File: /.external_modules/github.com/udjin10/yandex_compute_instance/f96532a351d512ef1888e6c12a3d47c65fa10479/main.tf:24-73

	Calling File: /main.tf:12-35

Check: CKV_YC_2: "Ensure compute instance does not have public IP."

	PASSED for resource: module.marketing_vm.yandex_compute_instance.vm[0]

	File: /.external_modules/github.com/udjin10/yandex_compute_instance/f96532a351d512ef1888e6c12a3d47c65fa10479/main.tf:24-73

	Calling File: /main.tf:12-35

Check: CKV_YC_4: "Ensure compute instance does not have serial console enabled."

	PASSED for resource: module.marketing_vm.yandex_compute_instance.vm[0]

	File: /.external_modules/github.com/udjin10/yandex_compute_instance/f96532a351d512ef1888e6c12a3d47c65fa10479/main.tf:24-73

	Calling File: /main.tf:12-35

Check: CKV_TF_1: "Ensure Terraform module sources use a commit hash"

	PASSED for resource: marketing_vm

	File: /main.tf:12-35

Check: CKV_TF_2: "Ensure Terraform module sources use a tag with a version number"

	PASSED for resource: marketing_vm

	File: /main.tf:12-35

Check: CKV_TF_1: "Ensure Terraform module sources use a commit hash"

	PASSED for resource: analytics_vm

	File: /main.tf:37-60

Check: CKV_TF_2: "Ensure Terraform module sources use a tag with a version number"

	PASSED for resource: analytics_vm

	File: /main.tf:37-60

Check: CKV_YC_19: "Ensure security group does not contain allow-all rules."

	PASSED for resource: module.vpc_dev.yandex_vpc_security_group.example

	File: /vpc/security.tf:58-86

	Calling File: /main.tf:3-8


```

```
terraform plan

reivol@Zabbix:~/GitHub/HOMEWORK/16_Oblachnaya_infrastruktura_Terraform/04_Prodvinutye_metody_raboty_with_Terraform$ terraform plan
data.template_file.cloudinit: Reading...
data.template_file.cloudinit: Read complete after 0s [id=63064b4707bab9048b4d3825107f6daefcda6ab524a5a6e07168e41ba0b3adf6]
module.marketing_vm.data.yandex_compute_image.my_image: Reading...
module.analytics_vm.data.yandex_compute_image.my_image: Reading...
module.vpc_dev.yandex_vpc_network.develop: Refreshing state... [id=enpujundsqjr3bu7667d]
module.analytics_vm.data.yandex_compute_image.my_image: Read complete after 0s [id=fd84h56p8ucfgqroscfv]
module.marketing_vm.data.yandex_compute_image.my_image: Read complete after 0s [id=fd84h56p8ucfgqroscfv]
module.vpc_dev.yandex_vpc_subnet.develop: Refreshing state... [id=e9bjqo7nrk5nmb0a3lph]
module.marketing_vm.yandex_compute_instance.vm[0]: Refreshing state... [id=fhmrq72q3a9o8rp6ektv]
module.analytics_vm.yandex_compute_instance.vm[0]: Refreshing state... [id=fhmfokn8m3kfr1uq944h]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create
  ~ update in-place

Terraform will perform the following actions:

  # module.analytics_vm.yandex_compute_instance.vm[0] will be updated in-place
  ~ resource "yandex_compute_instance" "vm" {
        id                        = "fhmfokn8m3kfr1uq944h"
        name                      = "stage-web-stage-0"
        # (16 unchanged attributes hidden)

      ~ network_interface {
          ~ nat                = true -> false
          ~ security_group_ids = [] -> (known after apply)
            # (9 unchanged attributes hidden)
        }

        # (5 unchanged blocks hidden)
    }

  # module.marketing_vm.yandex_compute_instance.vm[0] will be updated in-place
  ~ resource "yandex_compute_instance" "vm" {
        id                        = "fhmrq72q3a9o8rp6ektv"
        name                      = "develop-webs-0"
        # (16 unchanged attributes hidden)

      ~ network_interface {
          ~ nat                = true -> false
          ~ security_group_ids = [] -> (known after apply)
            # (9 unchanged attributes hidden)
        }

        # (5 unchanged blocks hidden)
    }

  # module.vpc_dev.yandex_vpc_security_group.example will be created
  + resource "yandex_vpc_security_group" "example" {
      + created_at = (known after apply)
      + folder_id  = "b1g51e5v9mh6c4gtt2he"
      + id         = (known after apply)
      + labels     = (known after apply)
      + name       = "example_dynamic"
      + network_id = "enpujundsqjr3bu7667d"
      + status     = (known after apply)

      + egress {
          + description       = "разрешить весь исходящий трафик"
          + from_port         = 0
          + id                = (known after apply)
          + labels            = (known after apply)
          + port              = -1
          + protocol          = "TCP"
          + to_port           = 65365
          + v4_cidr_blocks    = [
              + "0.0.0.0/0",
            ]
          + v6_cidr_blocks    = []
            # (2 unchanged attributes hidden)
        }

      + ingress {
          + description       = "разрешить входящий  http"
          + from_port         = -1
          + id                = (known after apply)
          + labels            = (known after apply)
          + port              = 80
          + protocol          = "TCP"
          + to_port           = -1
          + v4_cidr_blocks    = [
              + "0.0.0.0/0",
            ]
          + v6_cidr_blocks    = []
            # (2 unchanged attributes hidden)
        }
      + ingress {
          + description       = "разрешить входящий https"
          + from_port         = -1
          + id                = (known after apply)
          + labels            = (known after apply)
          + port              = 443
          + protocol          = "TCP"
          + to_port           = -1
          + v4_cidr_blocks    = [
              + "0.0.0.0/0",
            ]
          + v6_cidr_blocks    = []
            # (2 unchanged attributes hidden)
        }
      + ingress {
          + description       = "разрешить входящий ssh"
          + from_port         = -1
          + id                = (known after apply)
          + labels            = (known after apply)
          + port              = 22
          + protocol          = "TCP"
          + to_port           = -1
          + v4_cidr_blocks    = [
              + "0.0.0.0/0",
            ]
          + v6_cidr_blocks    = []
            # (2 unchanged attributes hidden)
        }
    }

Plan: 1 to add, 2 to change, 0 to destroy.
```